### PR TITLE
Using https in LiveFlight links / intent filters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,10 +24,10 @@
 
                 <data
                     android:host="liveflightapp.com"
-                    android:scheme="http" />
+                    android:scheme="https" />
                 <data
                     android:host="www.liveflightapp.com"
-                    android:scheme="http" />
+                    android:scheme="https" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/valxp/app/infiniteflightwatcher/InfoPane.java
+++ b/app/src/main/java/com/valxp/app/infiniteflightwatcher/InfoPane.java
@@ -364,7 +364,7 @@ public class InfoPane extends RelativeLayout implements View.OnClickListener {
 //        mInnerInfoPane.setBackgroundDrawable(getResources().getDrawable(bgDrawable));
         mImageLayout.setBackgroundDrawable(getResources().getDrawable(bgDrawable));
 //        mMyLoc.setBackgroundDrawable(getResources().getDrawable(bgDrawable));
-        mURL = "http://www.liveflightapp.com/?f=" + flight.getFlightID() + "&s=" + flight.getServer().getId();
+        mURL = "https://www.liveflightapp.com/?f=" + flight.getFlightID() + "&s=" + flight.getServer().getId();
         return true;
     }
 


### PR DESCRIPTION
LiveFlight uses https only since the rebuild - intent filters were not working correctly with old http links.
